### PR TITLE
Fix bug with api key getting cached, other small cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ docs/api_reference/_build
 docs/docs_skeleton/build
 docs/docs_skeleton/node_modules
 docs/docs_skeleton/yarn.lock
+
+secrets.toml


### PR DESCRIPTION
Found a bug in chat-with-sql and chat-with-documents examples where an OpenAI API Key could be cached unexpectedly and cause various problems. This PR fixes the bug. Also cleaned up a couple other small things.