### PR TITLE
search_and_chat: Store and re-render intermediate steps

### DIFF
--- a/streamlit_agent/search_and_chat.py
+++ b/streamlit_agent/search_and_chat.py
@@ -1,9 +1,8 @@
-from langchain.agents import StructuredChatAgent, AgentExecutor
+from langchain.agents import ConversationalChatAgent, AgentExecutor
 from langchain.callbacks import StreamlitCallbackHandler
 from langchain.chat_models import ChatOpenAI
 from langchain.memory import ConversationBufferMemory
 from langchain.memory.chat_message_histories import StreamlitChatMessageHistory
-from langchain.prompts.chat import MessagesPlaceholder
 from langchain.tools import DuckDuckGoSearchRun
 import streamlit as st
 
@@ -13,14 +12,25 @@ st.title("🦜 LangChain: Chat with search")
 openai_api_key = st.sidebar.text_input("OpenAI API Key", type="password")
 
 msgs = StreamlitChatMessageHistory()
-memory = ConversationBufferMemory(chat_memory=msgs, return_messages=True)
+memory = ConversationBufferMemory(
+    chat_memory=msgs, return_messages=True, memory_key="chat_history", output_key="output"
+)
 if len(msgs.messages) == 0 or st.sidebar.button("Reset chat history"):
     msgs.clear()
     msgs.add_ai_message("How can I help you?")
+    st.session_state.steps = {}
 
 avatars = {"human": "user", "ai": "assistant"}
-for msg in msgs.messages:
-    st.chat_message(avatars[msg.type]).write(msg.content)
+for idx, msg in enumerate(msgs.messages):
+    with st.chat_message(avatars[msg.type]):
+        # Render intermediate steps if any were saved
+        for step in st.session_state.steps.get(str(idx), []):
+            if step[0].tool == "_Exception":
+                continue
+            with st.expander(f"✅ **{step[0].tool}**: {step[0].tool_input}"):
+                st.write(step[0].log)
+                st.write(f"**{step[1]}**")
+        st.write(msg.content)
 
 if prompt := st.chat_input(placeholder="Who won the Women's U.S. Open in 2018?"):
     st.chat_message("user").write(prompt)
@@ -31,19 +41,16 @@ if prompt := st.chat_input(placeholder="Who won the Women's U.S. Open in 2018?")
 
     llm = ChatOpenAI(model_name="gpt-3.5-turbo", openai_api_key=openai_api_key, streaming=True)
     tools = [DuckDuckGoSearchRun(name="Search")]
-    chat_agent = StructuredChatAgent.from_llm_and_tools(
-        llm=llm,
-        tools=tools,
-        input_variables={"input", "history", "agent_scratchpad"},
-        memory_prompts=[MessagesPlaceholder(variable_name="history")],
-    )
+    chat_agent = ConversationalChatAgent.from_llm_and_tools(llm=llm, tools=tools)
     executor = AgentExecutor.from_agent_and_tools(
         agent=chat_agent,
         tools=tools,
         memory=memory,
+        return_intermediate_steps=True,
         handle_parsing_errors=True,
     )
     with st.chat_message("assistant"):
         st_cb = StreamlitCallbackHandler(st.container(), expand_new_thoughts=False)
-        response = executor.run(prompt, callbacks=[st_cb])
-        st.write(response)
+        response = executor(prompt, callbacks=[st_cb])
+        st.write(response["output"])
+        st.session_state.steps[str(len(msgs.messages) - 1)] = response["intermediate_steps"]


### PR DESCRIPTION
- Use `return_intermediate_steps=True` to retrieve and store tool usage for each agent call
- Re-render the tool usage ^ in subsequent re-runs for the relevant response
- Also switch to `ConversationalChatAgent` since it seems to perform better than `StructuredChatAgent`