### PR TITLE
Fix chat_with_documents.py callbacks

### DIFF
--- a/streamlit_agent/chat_with_documents.py
+++ b/streamlit_agent/chat_with_documents.py
@@ -55,7 +55,7 @@ class PrintRetrievalHandler(BaseCallbackHandler):
     def __init__(self, container):
         self.status = container.status("**Context Retrieval**")
 
-    def on_retriever_start(self, query: str, **kwargs):
+    def on_retriever_start(self, serialized: dict, query: str, **kwargs):
         self.status.write(f"**Question:** {query}")
         self.status.update(label=f"**Context Retrieval:** {query}")
 

--- a/streamlit_agent/chat_with_documents.py
+++ b/streamlit_agent/chat_with_documents.py
@@ -45,8 +45,16 @@ class StreamHandler(BaseCallbackHandler):
     def __init__(self, container: st.delta_generator.DeltaGenerator, initial_text: str = ""):
         self.container = container
         self.text = initial_text
+        self.run_id_ignore_token = None
+
+    def on_llm_start(self, serialized: dict, prompts: list, **kwargs):
+        # Workaround to prevent showing the rephrased question as output
+        if prompts[0].startswith("Human"):
+            self.run_id_ignore_token = kwargs.get("run_id")
 
     def on_llm_new_token(self, token: str, **kwargs) -> None:
+        if self.run_id_ignore_token == kwargs.get("run_id", False):
+            return
         self.text += token
         self.container.markdown(self.text)
 


### PR DESCRIPTION
# Problems
1. The question is not displayed in `on_retriever_start` because the function is missing a positional argument (issue #24).
2. The last agent's answer displays the rephrased question before the answer. Happens only in the last message.

Screenshot showing both issues:
![image](https://github.com/langchain-ai/streamlit-agent/assets/72821692/2897248e-1c89-4565-9283-286b20ceb6b9)

# Solution
1. Add the missing `serialized` parameter in `on_retriever_start` (as described in the [documentation](https://api.python.langchain.com/en/latest/callbacks/langchain.callbacks.base.BaseCallbackHandler.html?highlight=basecallbackhandler#langchain.callbacks.base.BaseCallbackHandler.on_retriever_start)).
2. Add a workaround for the rephrased question that appears in the answer:
    - Use `on_llm_start` callback to identify the `run_id` of the tokens from the "Human" question (LLM format for the human messages).
    - Save the `run_id` to ignore the tokens from the "Human".
    - Ignore the tokens from the `run_id` to ignore in `on_llm_new_token`, comparing with the `run_id` in the parameters.

# Testing
Tested locally, not showing the error described in #24, and not seeing the rephrased question in the last LLM answer.

Screenshot showing the result (same input as the previous screenshot):
![image](https://github.com/langchain-ai/streamlit-agent/assets/72821692/c933bf4e-bd17-4adf-a041-4c9f6278c958)
