### PR TITLE
Add warnings on chat_pandas_df

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This repository contains reference implementations of various LangChain agents a
 - `simple_feedback.py`: A chat app that allows the user to add feedback on responses using [streamlit-feedback](https://github.com/trubrics/streamlit-feedback), and link to the traces in [LangSmith](https://docs.smith.langchain.com/) ([View the app](https://langsmith-simple-feedback.streamlit.app/))
 - `chat_with_documents.py`: Chatbot capable of answering queries by referring custom documents ([View the app](https://langchain-document-chat.streamlit.app/))
 - `chat_with_sql_db.py`: Chatbot which can communicate with your database ([View the app](https://langchain-chat-sql.streamlit.app/))
-- `chat_pandas_df.py`: Chatbot to ask questions about a pandas DF ([View the app](https://langchain-chat-pandas.streamlit.app/))
+- `chat_pandas_df.py`: Chatbot to ask questions about a pandas DF (Note: uses `PythonAstREPLTool` which is vulnerable to arbitrary code execution,
+  see [langchain #7700](https://github.com/langchain-ai/langchain/issues/7700))
 
 Apps feature LangChain 🤝 Streamlit integrations such as the
 [Callback integration](https://python.langchain.com/docs/modules/callbacks/integrations/streamlit) and

--- a/streamlit_agent/chat_pandas_df.py
+++ b/streamlit_agent/chat_pandas_df.py
@@ -47,6 +47,11 @@ uploaded_file = st.file_uploader(
     on_change=clear_submit,
 )
 
+if not uploaded_file:
+    st.warning(
+        "This app uses LangChain's `PythonAstREPLTool` which is vulnerable to arbitrary code execution. Please use caution in deploying and sharing this app."
+    )
+
 if uploaded_file:
     df = load_data(uploaded_file)
 


### PR DESCRIPTION
Thank you @Lyutoon for reporting the issue

See https://github.com/langchain-ai/langchain/issues/7700 and https://github.com/langchain-ai/langchain/issues/5294 for more context

I am removing the chat_pandas_df app from Streamlit Cloud for now but keeping the app code with a warning in place. @amjadraza what do you think? I think we could run the agent which could generate pandas code but not actually execute it in the hosted demo, but I didn't see an easy way to configure the agent like that.

I [saw from Harrison](https://github.com/langchain-ai/langchain/pull/5640#issuecomment-1639605821) that this code will move to langchain-experimental soon.