### PR TITLE
Pass `handle_parsing_errors` param through `agent_executor_kwargs` in `Chat with pandas DataFrame` example

### DIFF
--- a/streamlit_agent/chat_pandas_df.py
+++ b/streamlit_agent/chat_pandas_df.py
@@ -79,7 +79,7 @@ if prompt := st.chat_input(placeholder="What is this data about?"):
         df,
         verbose=True,
         agent_type=AgentType.OPENAI_FUNCTIONS,
-        handle_parsing_errors=True,
+        agent_executor_kwargs={"handle_parsing_errors": True},
     )
 
     with st.chat_message("assistant"):


### PR DESCRIPTION
### Summary
The experimental function `create_pandas_dataframe_agent()` does not pass `handle_parsing_errors` to the constructor of the `AgentExecutor`. The result is that the agent fails to handle parsing errors (i.e. it does not retry or pass the error back to the LLM).

Instead, the parameter should be passed through the function's `agent_executor_kwargs` parameter.

### References
1. `create_pandas_dataframe_agent()`: https://github.com/langchain-ai/langchain/blob/v0.1.0/libs/experimental/langchain_experimental/agents/agent_toolkits/pandas/base.py#L278
2. `AgentExecutor`: https://github.com/langchain-ai/langchain/blob/v0.1.0/libs/langchain/langchain/agents/agent.py#L837